### PR TITLE
Cron

### DIFF
--- a/mobb.gemspec
+++ b/mobb.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "repp", "~> 0.2"
+  spec.add_dependency "whenever", "~> 0.10"
+  spec.add_dependency "parse-cron", "~> 0.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/mobb.gemspec
+++ b/mobb.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "repp", "~> 0.2"
+  spec.add_dependency "repp", "~> 0.3"
   spec.add_dependency "whenever", "~> 0.10"
   spec.add_dependency "parse-cron", "~> 0.1"
 


### PR DESCRIPTION
# Cron task

Add new DSL `cron` and `every`.
This method act like cron jobs.

# Notice

`cron` and `every` tasks needs `dest_to` condition.

# Example

execute block every hour between from 12:00 to 21:00

```
cron '0 12-21 * * *', dest_to: 'times_kinoppyd' do
  "Hi bro, wazup?
end
```

You can use [Whenever](https://github.com/javan/whenever) syntax instead of cron syntax

```
every :day, at: '14:00', dest_to: 'times_kinoppyd' do
  "ぞい"
end
```

See [Whenever](https://github.com/javan/whenever) to know more detail syntax.