### PR TITLE
Default conditions to ignore bot message

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,19 @@ end
 
 ## Conditions
 
-You can use conditions `ignore_bot` and `reply_to_me`.
+You can use conditions `react_to_bot`, `include_myself` and `reply_to_me`.
 
 ```ruby
 require 'mobb'
 set :service, 'slack'
 
-# You must set `ignore_bot` true when response same message
-on 'Yo', ignore_bot: true do
+# Mobb ignore all bot messages, but when set reply_to_bot true, Mobb react all bot messages
+# this example will act infinit loop when receive message 'Yo'
+on 'Yo', reply_to_bot: true do
   'Yo'
 end
 
+# This block react only message reply to bot
 on /Hi/, reply_to_me: true do
   "Hi #{@env.user.name}"
 end

--- a/lib/mobb/base.rb
+++ b/lib/mobb/base.rb
@@ -316,12 +316,6 @@ module Mobb
         end
       end
 
-      def ignore_bot(cond)
-        condition do
-          @env.bot? != cond
-        end
-      end
-
       def reply_to_me(cond)
         condition do
           @env.reply_to.include?(settings.name) == cond

--- a/lib/mobb/base.rb
+++ b/lib/mobb/base.rb
@@ -157,6 +157,13 @@ module Mobb
         /src\/kernel\/bootstrap\/[A-Z]/                     # maglev kernel files
       ]
 
+      DEFAULT_CONDITIONS = {
+        :message => {
+          :react_to_bot => false,
+          :include_myself => false
+        }
+      }
+
       attr_reader :events, :filters
 
       def reset!
@@ -210,6 +217,8 @@ module Mobb
 
       def compile!(type, pattern, options, &block)
         at = options.delete(:at)
+
+        options = DEFAULT_CONDITIONS[type].merge(options)
         options.each_pair { |option, args| send(option, *args) }
 
         matcher = case type
@@ -313,6 +322,20 @@ module Mobb
           end
           block.call(res)
           res
+        end
+      end
+
+      def react_to_bot(cond)
+        source_condition do
+          return true if !@env.respond_to?(:bot?) || cond
+          !@env.bot?
+        end
+      end
+
+      def include_myself(cond)
+        source_condition do
+          return true if !@env.respond_to?(:user) || cond
+          @env.user.name != settings.name
         end
       end
 


### PR DESCRIPTION
Mobb application default react bot messages, but this behavior is not safe. (e.g. infinity loop)
So Mobb have to ignore bot messages default, if application need to react bot message, write a explicit  conditions to on/receive block.

```
on 'Yo', react_to_bot: true do
  'Yo'
end
```