### PR TITLE
chain/trigger keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,31 @@ on /Yo/, reply_to_me: true do
 end
 ```
 
+# Chain methods
+
+If you want to act heavy task your bot, you can use chain/trigger syntax.
+
+```ruby
+require 'mobb'
+
+on 'taks start (\w+)' do |name|
+  chain 'heavy task1', 'heavy task2', name: name
+  'start!'
+end
+
+trigger 'heavy task1' do
+  payload = @env.payload
+  sleep 19
+  "task1 #{payload[:name]} done!"
+end
+
+trigger 'heavy task1' do
+  payload = @env.payload
+  sleep 30
+  "task2 #{payload[:name]} done!"
+end
+```
+
 # Service handlers
 
 Mobb is implemented based on [Repp](https://github.com/kinoppyd/repp) Interface.

--- a/lib/mobb/base.rb
+++ b/lib/mobb/base.rb
@@ -145,6 +145,11 @@ module Mobb
 
     def event_eval; throw :halt, yield; end
 
+    def chain(*args)
+      payload = args.last.instance_of?(Hash) ? args.pop : nil
+      @repp_options[:trigger] = { names: args, payload: payload }
+    end
+
     def settings
       self.class.settings
     end
@@ -207,6 +212,8 @@ module Mobb
       def cron(pattern, options = {}, &block) event(:ticker, pattern, options, &block); end
       alias :every :cron
 
+      def trigger(name, options = {}, &block) event(:trigger, name, options, &block); end
+
       def event(type, pattern, options, &block)
         signature = compile!(type, pattern, options, &block)
         (@events[type] ||= []) << signature
@@ -229,6 +236,8 @@ module Mobb
                     compile(pattern, options)
                   when :ticker
                     compile_cron(pattern, at)
+                  when :trigger
+                    compile(pattern, options)
                   else
                     compile(pattern, options)
                   end

--- a/lib/mobb/base.rb
+++ b/lib/mobb/base.rb
@@ -63,8 +63,11 @@ module Mobb
 
     def call!(env)
       @env = env
+      @body = nil
+      @repp_options = {}
+      @attachments = {}
       invoke { dispatch! }
-      [@body, @attachments]
+      [@body, @repp_options, @attachments]
     end
 
     def dispatch!


### PR DESCRIPTION
This is new feature for mobb/repp.
Chain methods from on/receive block.

```
require 'mobb'

on 'chrono' do
  chain 'trigger', 'crorss'
  'chrono'
end

trigger 'trigger' do
  'trigger'
end

trigger 'cross' do
  'cross'
end
```

and you can set payload

```
require 'mobb'

on 'task' do
  chain 'slow_task', name: 'hoge'
end

trigger 'slow_task' do
  sleep 10
  "task #{@env.payload[:name]} done
end