### PR TITLE
Fix block arguments as array, not expanded

### DIFF
--- a/lib/mobb/base.rb
+++ b/lib/mobb/base.rb
@@ -141,7 +141,7 @@ module Mobb
         case res
         when ::Mobb::Matcher::Matched
           @matched = res.matched
-          block ? block[self, *(res.captures)] : yield(self, *(res.captures))
+          block ? block[self, res.captures] : yield(self, res.captures)
         when TrueClass
           block ? block[self] : yield(self)
         else


### PR DESCRIPTION
```
require 'mobb'

on /echo (\w+) (\d+) times/ do |word, count|
  word * count.to_i
end
```

```
ruby app.rb
== Mobb (v0.5.0) is in da house with Shell. Make some noise!
echo e 10 times
wrong number of arguments (given 1, expected 2)
app.rb:7:in `block in <main>'
...
```